### PR TITLE
Build samples for Java and Node as Docker images

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -83,12 +83,10 @@ kubectl logs -f -c sidecar $(kubectl get pod -l function=echo -o jsonpath='{.ite
 ./mvnw clean package -f samples/java/greeter/pom.xml
 ```
 
-=== Mount the Samples Folder into the Minikube VM
+=== Build the Docker container for the function code
 
 ```
-# In yet another terminal
-minikube mount samples:/resources
-# Leave this running, use another terminal from now on
+./faas create -f greeter -v v0001 -p samples/java/
 ```
 
 === Create a New Topic
@@ -111,8 +109,11 @@ kubectl create -f samples/greeter-function.yaml
 
 == Add a Node Function
 
-=== Have the Samples Folder Mounted on the Minikube VM
-(see above if you haven't done this yet)
+=== Build the Docker container for the function code
+
+```
+./faas create -f square -v v0001 -p samples/node/
+```
 
 === Create a New Topic
 

--- a/event-dispatcher/src/main/java/io/sk8s/event/dispatcher/JobLauncher.java
+++ b/event-dispatcher/src/main/java/io/sk8s/event/dispatcher/JobLauncher.java
@@ -70,10 +70,6 @@ public class JobLauncher {
 						.withVolumes(new VolumeBuilder()
 								.withName("pipes")
 								.withEmptyDir(new EmptyDirVolumeSourceBuilder().build())
-								.build(),
-							new VolumeBuilder()
-								.withName("resources")
-								.withNewHostPath("/resources")
 								.build()
 						)
 					.endSpec()
@@ -121,8 +117,7 @@ public class JobLauncher {
 
 	private VolumeMount[] buildSharedVolumeMounts() {
 		return new VolumeMount[] {
-				new VolumeMountBuilder().withMountPath("/pipes").withName("pipes").build(),
-				new VolumeMountBuilder().withMountPath("/resources").withName("resources").build()
+				new VolumeMountBuilder().withMountPath("/pipes").withName("pipes").build()
 		};
 	}
 

--- a/faas
+++ b/faas
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+function print_usage() {
+cat <<EOF
+
+USAGE: faas create -f <function> -p <path> -v <version>
+  This command will build the function based on the code available in the path directory
+
+Flags:
+
+[*] -f  | --function - the name of the function
+    -p  | --path - the path to the function code (defaults to current directory)
+    -v  | --version - the version of the function created (defaults to v0001)
+
+[*] = Required arguments
+
+EOF
+}
+
+function create() {
+  echo "Creating $FUNCTION $FNPATH $VERSION"
+  docker build -t "sk8s/${FUNCTION}:${VERSION}" $FNPATH
+}
+
+# ======================================= FUNCTIONS END =======================================
+
+if [[ $1 == "--help" || $1 == "-h" ]] ; then
+    print_usage
+    exit 0
+fi
+
+if [[ $# == 0 ]]; then
+  print_usage
+  exit 0
+fi
+
+COMMAND="$1"
+shift
+
+while [[ $# > 0 ]]
+do
+key="$1"
+case ${key} in
+ -f|--function)
+ FUNCTION="$2"
+ shift
+ ;;
+ -p|--path)
+ FNPATH="$2"
+ shift
+ ;;
+ -v|--version)
+ VERSION="$2"
+ shift
+ ;;
+ --help)
+ print_usage
+ exit 0
+ ;;
+ *)
+ echo ""
+ echo "ERROR: Invalid option: [$1]"
+ print_usage
+ exit 1
+ ;;
+esac
+shift
+done
+
+# ======================================= DEFAULTS ============================================
+FNPATH="${FNPATH:-.}"
+VERSION="${VERSION:-v0001}"
+# ======================================= DEFAULTS END ========================================
+if [[ "${COMMAND}" == "create" ]]; then
+  create
+else
+  echo "$COMMAND is an invalid command"
+  exit 1;
+fi
+

--- a/samples/greeter-function.yaml
+++ b/samples/greeter-function.yaml
@@ -3,10 +3,10 @@ kind: Function
 metadata:
   name: greeter
 spec:
-  image: sk8s/java-function-invoker:v0001
+  image: sk8s/greeter:v0001
   protocol: http
   input: names
   output: greetings
   env:
   - name: FUNCTION_URI
-    value: file:///resources/java/greeter/target/greeter-1.0.0.jar?functions.Greeter
+    value: file:///functions/java/greeter-1.0.0.jar?functions.Greeter

--- a/samples/java/Dockerfile
+++ b/samples/java/Dockerfile
@@ -1,0 +1,2 @@
+FROM sk8s/java-function-invoker:v0001
+ADD greeter/target/greeter-1.0.0.jar /functions/java/greeter-1.0.0.jar

--- a/samples/node/Dockerfile
+++ b/samples/node/Dockerfile
@@ -1,0 +1,2 @@
+FROM sk8s/node-function-invoker:latest
+ADD square.js /functions/node/square.js

--- a/samples/square-function.yaml
+++ b/samples/square-function.yaml
@@ -3,10 +3,10 @@ kind: Function
 metadata:
   name: square
 spec:
-  image: sk8s/node-function-invoker:latest
+  image: sk8s/square:v0001
   protocol: http
   input: numbers
   output: greetings
   env:
   - name: FUNCTION_URI
-    value: /resources/node/square.js
+    value: /functions/node/square.js

--- a/teardown
+++ b/teardown
@@ -3,13 +3,13 @@
 kubectl delete functions --all
 kubectl delete topics --all
 
-kubectl delete all -l app=topic-controller
-kubectl delete all -l app=topic-gateway
-kubectl delete all -l app=event-dispatcher
-
 kubectl delete all -l function=echo
 kubectl delete all -l function=greeter
 kubectl delete all -l function=square
+
+kubectl delete all -l app=topic-controller
+kubectl delete all -l app=topic-gateway
+kubectl delete all -l app=event-dispatcher
 
 kubectl delete crd/functions.extensions.sk8s.io
 kubectl delete crd/topics.extensions.sk8s.io
@@ -18,3 +18,6 @@ kubectl delete all -l app=kafka
 kubectl delete all -l app=zipkin
 kubectl delete all -l app=metrics
 kubectl delete cm -l app=metrics
+
+docker rmi --force sk8s/greeter:v0001
+docker rmi --force sk8s/square:v0001


### PR DESCRIPTION
- adding a faas command line to create the images

- adding Dockerfile for java and node sample functions

- changing the function yaml to reference the new images

- removing sample docker images in teardown

- removing \resources mount in JobLauncher

- updating README