### PR TITLE
Add python-function-invoker

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -159,6 +159,33 @@ kubectl create -f samples/square-function.yaml
 ./publish numbers 2
 ```
 
+
+== Add a Python Function
+
+=== Have the Samples Folder Mounted on the Minikube VM
+(see above if you haven't done this yet)
+
+=== Create a New Topic
+
+```
+kubectl create -f samples/tweets.yaml
+```
+
+=== Create the Function
+
+```
+kubectl create -f samples/sentiments.yaml
+```
+
+=== Publish a Message
+
+The function performs sentiment analysis on tweets. It accepts JSON and looks only at the `text` field. The input
+is in the form of an array (sorry about the escaped quotes).
+
+```
+./publish tweets "[{\"text\":\"happy happy happy\"},{\"text\":\"sad sad sad\"}]"
+```
+
 == Tear it all down
 
 ```

--- a/function-invokers/pom.xml
+++ b/function-invokers/pom.xml
@@ -19,6 +19,8 @@
 		<module>java-function-invoker</module>
 		<module>node-function-invoker</module>
 		<module>shell-function-invoker</module>
+		<module>python2-function-invoker</module>
+
   </modules>
 
 </project>

--- a/function-invokers/python2-function-invoker/pom.xml
+++ b/function-invokers/python2-function-invoker/pom.xml
@@ -1,0 +1,43 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>python2-function-invoker</artifactId>
+	<packaging>pom</packaging>
+
+	<parent>
+		<groupId>io.sk8s</groupId>
+		<artifactId>sk8s-parent</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+		<relativePath />
+	</parent>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>io.fabric8</groupId>
+				<artifactId>docker-maven-plugin</artifactId>
+				<version>${docker-maven.version}</version>
+				<executions>
+					<execution>
+						<id>dockerize</id>
+						<phase>package</phase>
+						<goals>
+							<goal>build</goal>
+						</goals>
+						<configuration>
+							<images>
+								<image>
+									<name>sk8s/${project.artifactId}</name>
+									<build>
+										<dockerFile>Dockerfile</dockerFile>
+									</build>
+								</image>
+							</images>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/function-invokers/python2-function-invoker/src/main/docker/Dockerfile
+++ b/function-invokers/python2-function-invoker/src/main/docker/Dockerfile
@@ -1,0 +1,5 @@
+FROM continuumio/anaconda:5.0.0
+ADD image/* /
+RUN mkdir -p /resources
+CMD ["/bin/bash","-c", "/runner.sh"]
+

--- a/function-invokers/python2-function-invoker/src/main/docker/image/funcrunner.py
+++ b/function-invokers/python2-function-invoker/src/main/docker/image/funcrunner.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+__copyright__ = '''
+Copyright 2017 the original author or authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+'''
+__author__ = 'David Turanski'
+
+import sys
+import os
+import zipfile
+import importlib
+import ntpath
+import os.path
+import traceback
+from urlparse import urlparse
+from shutil import copyfile
+from os import listdir
+from os.path import isfile
+
+def run_function(func):
+    while True:
+        try:
+            data = raw_input()
+            func(data)
+        except KeyboardInterrupt:
+            exit(0)
+        except:
+            traceback.print_exc(file=sys.stderr)
+
+
+def install_function():
+    try:
+        function_uri = os.environ['FUNCTION_URI']
+        url = urlparse(function_uri)
+        if (url.scheme == 'file'):
+            if not os.path.isfile(url.path):
+                sys.stderr.write("file %s does not exist\n" % url.path)
+                exit(1)
+
+            filename, extension = os.path.splitext(url.path)
+
+            if (extension == '.zip'):
+                zip_ref = zipfile.ZipFile(url.path, 'r')
+                zip_ref.extractall('.')
+                zip_ref.close()
+                sys.stderr.write("Files extracted\n")
+            elif (extension == '.py'):
+                copyfile(url.path, ('./%s' % ntpath.basename(url.path)))
+
+            for f in listdir('.'):
+                sys.stderr.write("%s\n" % f)
+
+        else:
+            sys.stderr.write("scheme %s is not supported\n" % url.scheme)
+            exit(1)
+
+        indx = len('handler=')
+        if len(url.query) <= indx or url.query[0:indx] != 'handler=':
+            sys.stderr.write("FUNCTION_URI missing handler\n")
+            exit(1)
+        mod_name, func_name = url.query[indx:].rsplit('.', 1)
+        mod = importlib.import_module(mod_name)
+        return getattr(mod, func_name)
+
+    except KeyError:
+        sys.stderr.write("required environment variable FUNCTION_URI is missing\n")
+        exit(1)
+
+
+function = install_function()
+run_function(function)

--- a/function-invokers/python2-function-invoker/src/main/docker/image/runner.sh
+++ b/function-invokers/python2-function-invoker/src/main/docker/image/runner.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+while [ ! -e /pipes/input ]
+do
+	echo "Waiting for input pipe to appear"
+	sleep 1
+done
+
+python -u ./funcrunner.py < pipes/input > pipes/output

--- a/samples/python/sentiment_service.py
+++ b/samples/python/sentiment_service.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+
+'''
+sentiment_service.py
+~~~~~~~~~~~~~~~~~~~~
+
+App implements a sentiment analysis pipeline. 
+
+'''
+import cPickle as pickle
+import pandas as pd
+import requests
+import json
+import warnings
+
+warnings.filterwarnings("ignore")
+
+resp = requests.get(
+    "https://raw.githubusercontent.com/crawles/gpdb_sentiment_analysis_twitter_model/master/twitter_sentiment_model.pkl")
+resp.raise_for_status()
+cl = pickle.loads(resp.content)
+
+
+def regex_preprocess(raw_tweets):
+    tweets = map(lambda t: t['text'], raw_tweets)
+
+    pp_text = pd.Series(tweets)
+
+    user_pat = '(?<=^|(?<=[^a-zA-Z0-9-_\.]))@([A-Za-z]+[A-Za-z0-9]+)'
+    http_pat = '(https?:\/\/(?:www\.|(?!www))[^\s\.]+\.[^\s]{2,}|www\.[^\s]+\.[^\s]{2,})'
+    repeat_pat, repeat_repl = "(.)\\1\\1+", '\\1\\1'
+
+    pp_text = pp_text.str.replace(pat=user_pat, repl='USERNAME')
+    pp_text = pp_text.str.replace(pat=http_pat, repl='URL')
+    pp_text.str.replace(pat=repeat_pat, repl=repeat_repl)
+    return pp_text
+
+
+def post_process(polarities, tweets):
+    result = []
+    try:
+        for i, polarity in enumerate(polarities):
+            result.append({'polarity': round(polarity,2), 'text': tweets[i]})
+
+        return json.dumps(result)
+
+    except:
+        return json.dumps([])
+
+def process(data):
+    # Array of raw tweets
+    raw_tweets = json.loads(str(data))
+    # Convert to {[text1,text2,...]}
+    tweets = regex_preprocess(raw_tweets)
+
+    ## run the prediction
+    prediction = cl.predict_proba(tweets)[:][:, 1]
+
+    print(post_process(prediction.tolist(),tweets))
+
+if __name__ == '__main__':
+
+    while True:
+        data = raw_input()
+        process(data)

--- a/samples/sentiments-function.yaml
+++ b/samples/sentiments-function.yaml
@@ -1,0 +1,12 @@
+apiVersion: extensions.sk8s.io/v1
+kind: Function
+metadata:
+  name: sentiments
+spec:
+  image: sk8s/python2-function-invoker:latest
+  protocol: stdio
+  input: tweets
+  output: sentiments
+  env:
+  - name: FUNCTION_URI
+    value: file:///resources/python/sentiment_service.py?handler=sentiment_service.process

--- a/samples/sentiments-topic.yaml
+++ b/samples/sentiments-topic.yaml
@@ -1,0 +1,4 @@
+apiVersion: extensions.sk8s.io/v1
+kind: Topic
+metadata:
+  name: sentiments

--- a/samples/tweets-topic.yaml
+++ b/samples/tweets-topic.yaml
@@ -1,0 +1,4 @@
+apiVersion: extensions.sk8s.io/v1
+kind: Topic
+metadata:
+  name: tweets

--- a/teardown
+++ b/teardown
@@ -11,6 +11,8 @@ kubectl delete all -l function=echo
 kubectl delete all -l function=greeter
 kubectl delete all -l function=square
 kubectl delete all -l function=grpc
+kubectl delete all -l function=sentiments
+
 
 kubectl delete crd/functions.extensions.sk8s.io
 kubectl delete crd/topics.extensions.sk8s.io


### PR DESCRIPTION
This adds a Python 2 function invoker. The image adds from [anaconda](https://hub.docker.com/r/continuumio/anaconda) which is based Python 2 using stdio.  There presumably would be a parallel one for Python 3. 

The sample is an ML tweet sentiment analyzer that imports a number of data analysis and ML libraries which are included with Anaconda and requires Python 2.  After several unsuccessful attempts to use an approach similar to [AWS Lambda for Python ](http://docs.aws.amazon.com/lambda/latest/dg/lambda-python-how-to-create-deployment-package.html) for this app, I decided to save that for a rainy day.

AWS Lambda requires the developer to create a deployment zip file with all dependencies installed in the root directory. This function invoker supports this, or tries to at least, if you set `FUNCTION_URI` to a zip file.  This works standalone but YMMV with docker.  I haven't yet tested with a simpler example.  Using Anaconda , the function pod actually loads faster since there is minimal initialization required. 

A characteristic of both a full Anaconda image and having the AWS approach is that neither require the installation of Python packages at runtime, as would be the case with creating a virtual environment or performing pip/conda installs. I tried creating a virtual environment at runtime as specified by the function. It takes too long to initialize for FaaS. Anaconda has a 3GB image but seems to spin up quickly.

Also, the URL requires `handler` as a query parameter. Based on previous discussions, I thought I would give it a try until we decide on the final format.