### PR TITLE
allow k8s to generate random nodePort

### DIFF
--- a/config/topic-gateway-service-nodeport.yaml
+++ b/config/topic-gateway-service-nodeport.yaml
@@ -10,7 +10,6 @@ spec:
   - port: 80
     name: http
     targetPort: 8080
-    nodePort: 30111
   - port: 443
     name: https
     targetPort: 8443


### PR DESCRIPTION
otherwise the port may be already allocated in case of multiple deployments, as seen here: https://ci.faas.to.cf-app.com/teams/pfs/pipelines/faas_integration/jobs/build-sk8s-and-invoker-java/builds/25