### PR TITLE
Adding `create.crd` and `create.faas` flags

### DIFF
--- a/charts/sk8s/templates/NOTES.txt
+++ b/charts/sk8s/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{- if .Values.create.faas -}}
 1. Get the application URL by running these commands:
 {{- if contains "NodePort" .Values.topicGateway.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }}-topic-gateway)
@@ -13,3 +14,6 @@
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:{{ .Values.topicGateway.service.externalPort }}
 {{- end }}
+{{- else -}}
+FaaS was not installed since "create.faas=false" was specified.
+{{- end -}}

--- a/charts/sk8s/templates/event-dispatcher-deployment.yaml
+++ b/charts/sk8s/templates/event-dispatcher-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.create.faas -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -28,3 +29,4 @@ spec:
             value: {{ template "fullname" . }}-kafka:9092
           - name: SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES
             value: {{ template "fullname" . }}-zookeeper:2181
+{{- end -}}

--- a/charts/sk8s/templates/function-resource.yaml
+++ b/charts/sk8s/templates/function-resource.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.create.crd -}}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -12,3 +13,4 @@ spec:
     kind: Function
     plural: functions
     singular: function
+{{- end -}}

--- a/charts/sk8s/templates/kafka-deployment.yaml
+++ b/charts/sk8s/templates/kafka-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.create.faas -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -34,3 +35,4 @@ spec:
                   fieldPath: status.podIP
             - name: KAFKA_ZOOKEEPER_CONNECT
               value: {{ template "fullname" . }}-zookeeper:2181
+{{- end -}}

--- a/charts/sk8s/templates/kafka-service.yaml
+++ b/charts/sk8s/templates/kafka-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.create.faas -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,3 +19,4 @@ spec:
     app: {{ template "name" . }}
     component: kafka
     release: {{ .Release.Name }}
+{{- end -}}

--- a/charts/sk8s/templates/topic-controller-deployment.yaml
+++ b/charts/sk8s/templates/topic-controller-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.create.faas -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -28,3 +29,4 @@ spec:
             value: {{ template "fullname" . }}-kafka:9092
           - name: SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES
             value: {{ template "fullname" . }}-zookeeper:2181
+{{- end -}}

--- a/charts/sk8s/templates/topic-gateway-deployment.yaml
+++ b/charts/sk8s/templates/topic-gateway-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.create.faas -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -30,3 +31,4 @@ spec:
             value: {{ template "fullname" . }}-kafka:9092
           - name: SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES
             value: {{ template "fullname" . }}-zookeeper:2181
+{{- end -}}

--- a/charts/sk8s/templates/topic-gateway-service.yaml
+++ b/charts/sk8s/templates/topic-gateway-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.create.faas -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -19,3 +20,4 @@ spec:
     app: {{ template "name" . }}
     component: topic-gateway
     release: {{ .Release.Name }}
+{{- end -}}

--- a/charts/sk8s/templates/topic-resource.yaml
+++ b/charts/sk8s/templates/topic-resource.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.create.crd -}}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -12,3 +13,4 @@ spec:
     kind: Topic
     plural: topics
     singular: topic
+{{- end -}}

--- a/charts/sk8s/templates/zipkin-deployment.yaml
+++ b/charts/sk8s/templates/zipkin-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.create.faas -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -39,3 +40,4 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.namespace
+{{- end -}}

--- a/charts/sk8s/templates/zipkin-service.yaml
+++ b/charts/sk8s/templates/zipkin-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.create.faas -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -19,3 +20,4 @@ spec:
     app: {{ template "name" . }}
     component: zipkin
     release: {{ .Release.Name }}
+{{- end -}}

--- a/charts/sk8s/templates/zookeeper-deployment.yaml
+++ b/charts/sk8s/templates/zookeeper-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.create.faas -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -28,3 +29,4 @@ spec:
             value: "1"
           - name: ZOOKEEPER_SERVER_1
             value: {{ template "fullname" . }}-zookeeper
+{{- end -}}

--- a/charts/sk8s/templates/zookeeper-service.yaml
+++ b/charts/sk8s/templates/zookeeper-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.create.faas -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -19,3 +20,4 @@ spec:
     app: {{ template "name" . }}
     component: zookeeper
     release: {{ .Release.Name }}
+{{- end -}}

--- a/charts/sk8s/values.yaml
+++ b/charts/sk8s/values.yaml
@@ -1,6 +1,9 @@
 # Default values for sk8s.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+create:
+  crd: true
+  faas: true
 eventDispatcher:
   replicaCount: 1
   image:


### PR DESCRIPTION
- booth default to true

- this allows for separate releases for crd and faas

- also allows for multiple faas releases in different namespaces