### PR TITLE
Adding a kafka-tools deployment

### DIFF
--- a/config/kafka/kafka.yaml
+++ b/config/kafka/kafka.yaml
@@ -51,7 +51,7 @@ spec:
     spec:
       containers:
       - name: zookeeper
-        image: wurstmeister/zookeeper
+        image: wurstmeister/zookeeper:3.4.6
         ports:
         - containerPort: 2181
         env:
@@ -78,7 +78,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: wurstmeister/kafka
+        image: wurstmeister/kafka:0.11.0.1
         ports:
         - containerPort: 9092
         env:

--- a/config/kafka/tools/kafka-tools.yaml
+++ b/config/kafka/tools/kafka-tools.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: kafka
+    component: kafka-tools
+  name: kafka-tools
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: kafka
+        component: kafka-tools
+    spec:
+      containers:
+      - name: kafka-tools
+        image: wurstmeister/kafka:0.11.0.1
+        command: ["sleep", "infinity"]


### PR DESCRIPTION
- setting kafka/zookeeper to specific tags so we know the version

- adding a kafka-tools pod as a separate deployment with `kubectl apply -f config/kafka/tools`

- attach to kafka-tools container using:
  kubectl exec -it $(kubectl get pod -l component=kafka-tools -o jsonpath='{.items[0].metadata.name}') -- /bin/bash

- we can now run commands like these from the `kafka-tools` container:
  /opt/kafka/bin/kafka-broker-api-versions.sh  --bootstrap-server kafka:9092
  /opt/kafka/bin/kafka-consumer-groups.sh --bootstrap-server kafka:9092 --list
  /opt/kafka/bin/kafka-topics.sh --list --zookeeper zookeeper:2181
  /opt/kafka/bin/kafka-console-consumer.sh --bootstrap-server kafka:9092 --topic names --from-beginning
  /opt/kafka/bin/kafka-console-consumer.sh --bootstrap-server kafka:9092 --topic sleuth --from-beginning

- tried using the `kafka-broker` but some networking/DNS issue prevented this from working properly, it works when accessing from a separate container