### PR TITLE
Add sidecar image var and chart values

### DIFF
--- a/charts/sk8s/templates/function-controller-deployment.yaml
+++ b/charts/sk8s/templates/function-controller-deployment.yaml
@@ -47,5 +47,7 @@ spec:
             value: {{ template "fullname" . }}-kafka:9092
           - name: SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES
             value: {{ template "fullname" . }}-zookeeper:2181
+          - name: SK8S_FUNCTION_CONTROLLER_SIDECAR_TAG
+            value: {{ .Values.functionController.sidecar.image.tag }}
       serviceAccountName: {{ template "fullname" . }}-sa
 {{- end -}}

--- a/charts/sk8s/values.yaml
+++ b/charts/sk8s/values.yaml
@@ -18,9 +18,7 @@ functionController:
     pullPolicy: IfNotPresent
   sidecar:
     image:
-      repository: sk8s/function-sidecar
       tag: 0.0.1-SNAPSHOT
-      pullPolicy: IfNotPresent
   service:
     name: http
     type: ClusterIP

--- a/charts/sk8s/values.yaml
+++ b/charts/sk8s/values.yaml
@@ -16,6 +16,11 @@ functionController:
     repository: sk8s/function-controller
     tag: 0.0.1-SNAPSHOT
     pullPolicy: IfNotPresent
+  sidecar:
+    image:
+      repository: sk8s/function-sidecar
+      tag: 0.0.1-SNAPSHOT
+      pullPolicy: IfNotPresent
   service:
     name: http
     type: ClusterIP

--- a/config/function-controller-deployment.yaml
+++ b/config/function-controller-deployment.yaml
@@ -36,4 +36,6 @@ spec:
           value: kafka:9092
         - name: SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES
           value: zookeeper:2181
+        - name: SK8S_FUNCTION_CONTROLLER_SIDECAR_TAG
+          value: sk8s/function-sidecar
       serviceAccountName: sk8s-sa

--- a/config/function-controller-deployment.yaml
+++ b/config/function-controller-deployment.yaml
@@ -37,5 +37,5 @@ spec:
         - name: SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES
           value: zookeeper:2181
         - name: SK8S_FUNCTION_CONTROLLER_SIDECAR_TAG
-          value: sk8s/function-sidecar
+          value: sk8s/function-sidecar:0.0.1-SNAPSHOT
       serviceAccountName: sk8s-sa


### PR DESCRIPTION
Add sidecar image variable (`SK8S_FUNCTION_CONTROLLER_SIDECAR_TAG`) and corresponding chart values, in order to enable the override of the tag during Helm deployments.