### PR TITLE
Launch optionally with isolated classpath (support for Flux)

### DIFF
--- a/function-invokers/java-function-invoker/README.md
+++ b/function-invokers/java-function-invoker/README.md
@@ -1,0 +1,21 @@
+Testing locally:
+
+```
+$ mvn install dockerfile:build
+$ docker run -ti -p 8080:8080 -v `pwd`/target/test-classes:/classes sk8s/java-function-invoker:0.0.1-SNAPSHOT --function.uri=file:classes?io.sk8s.invoker.java.function.Doubler
+```
+
+Then
+
+```
+$ curl -v localhost:8080 -H "Content-Type: text/plain" -d 5
+10
+```
+
+For a function of `Flux` it only works if you explicitly start the app with `--function.runner.isolated=true`, i.e:
+
+```
+$ docker run -ti -p 8080:8080 -v `pwd`/target/test-classes:/classes sk8s/java-function-invoker:0.0.1-SNAPSHOT \
+  --function.uri=file:classes?io.sk8s.invoker.java.function.FluxDoubler \
+  --function.runner.isolated=true
+```

--- a/function-invokers/java-function-invoker/README.md
+++ b/function-invokers/java-function-invoker/README.md
@@ -12,10 +12,3 @@ $ curl -v localhost:8080 -H "Content-Type: text/plain" -d 5
 10
 ```
 
-For a function of `Flux` it only works if you explicitly start the app with `--function.runner.isolated=true`, i.e:
-
-```
-$ docker run -ti -p 8080:8080 -v `pwd`/target/test-classes:/classes sk8s/java-function-invoker:0.0.1-SNAPSHOT \
-  --function.uri=file:classes?io.sk8s.invoker.java.function.FluxDoubler \
-  --function.runner.isolated=true
-```

--- a/function-invokers/java-function-invoker/src/main/java/io/sk8s/invoker/java/server/ApplicationRunner.java
+++ b/function-invokers/java-function-invoker/src/main/java/io/sk8s/invoker/java/server/ApplicationRunner.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sk8s.invoker.java.server;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Map;
+
+import javax.annotation.PreDestroy;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.context.support.LiveBeansView;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Driver class for running a Spring Boot application via an isolated classpath.
+ * Initialize an instance of this class with the class loader to be used and the name of
+ * the main class (usually a <code>@SpringBootApplication</code>), and then
+ * {@link #run(String...)} it, cleaning up with a call to {@link #close()}.
+ * 
+ * @author Dave Syer
+ *
+ */
+public class ApplicationRunner {
+
+	private static Log logger = LogFactory.getLog(ApplicationRunner.class);
+
+	private final ClassLoader classLoader;
+
+	private final String source;
+
+	private Object app;
+
+	public ApplicationRunner(ClassLoader classLoader, String source) {
+		this.classLoader = classLoader;
+		this.source = source;
+	}
+
+	public void run(String... args) {
+		ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();
+		try {
+			ClassUtils.overrideThreadContextClassLoader(this.classLoader);
+			Class<?> cls = this.classLoader.loadClass(ContextRunner.class.getName());
+			this.app = cls.newInstance();
+			runContext(this.source, Collections.singletonMap(
+					LiveBeansView.MBEAN_DOMAIN_PROPERTY_NAME, "function-invoker"), args);
+		}
+		catch (Exception e) {
+			logger.error("Cannot deploy", e);
+		}
+		finally {
+			ClassUtils.overrideThreadContextClassLoader(contextLoader);
+		}
+		RuntimeException e = getError();
+		if (e != null) {
+			throw e;
+		}
+	}
+
+	@PreDestroy
+	public void close() {
+		closeContext();
+	}
+
+	private RuntimeException getError() {
+		if (this.app == null) {
+			return null;
+		}
+		Method method = ReflectionUtils.findMethod(this.app.getClass(), "getError");
+		Throwable e;
+		e = (Throwable) ReflectionUtils.invokeMethod(method, this.app);
+		if (e == null) {
+			return null;
+		}
+		if (e instanceof RuntimeException) {
+			return (RuntimeException) e;
+		}
+		return new IllegalStateException("Cannot launch", e);
+	}
+
+	private void runContext(String mainClass, Map<String, String> properties,
+			String... args) {
+		Method method = ReflectionUtils.findMethod(this.app.getClass(), "run",
+				String.class, Map.class, String[].class);
+		ReflectionUtils.invokeMethod(method, this.app, mainClass, properties, args);
+	}
+
+	private void closeContext() {
+		if (this.app != null) {
+			Method method = ReflectionUtils.findMethod(this.app.getClass(), "close");
+			ReflectionUtils.invokeMethod(method, this.app);
+		}
+	}
+
+}

--- a/function-invokers/java-function-invoker/src/main/java/io/sk8s/invoker/java/server/ContextRunner.java
+++ b/function-invokers/java-function-invoker/src/main/java/io/sk8s/invoker/java/server/ContextRunner.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sk8s.invoker.java.server;
+
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.util.Map;
+
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Utility class for starting a Spring Boot application in a separate thread. Best used
+ * from an isolated class loader, e.g. through {@link ApplicationRunner}.
+ * 
+ * @author Dave Syer
+ *
+ */
+public class ContextRunner {
+
+	private ConfigurableApplicationContext context;
+	private Thread runThread;
+	private boolean running = false;
+	private Throwable error;
+	private long timeout = 120000;
+
+	public void run(final String source, final Map<String, Object> properties,
+			final String... args) {
+		// Run in new thread to ensure that the context classloader is setup
+		this.runThread = new Thread(new Runnable() {
+			@Override
+			public void run() {
+				try {
+					resetUrlHandler();
+					StandardEnvironment environment = new StandardEnvironment();
+					environment.getPropertySources().addAfter(
+							StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME,
+							new MapPropertySource("appDeployer", properties));
+					context = new SpringApplicationBuilder(source)
+							.environment(environment).run(args);
+				}
+				catch (Throwable ex) {
+					error = ex;
+				}
+
+			}
+		});
+		this.runThread.start();
+		try {
+			this.runThread.join(timeout);
+			this.running = context != null && context.isRunning();
+		}
+		catch (InterruptedException e) {
+			this.running = false;
+			Thread.currentThread().interrupt();
+		}
+
+	}
+
+	public void close() {
+		if (this.context != null) {
+			this.context.close();
+			resetUrlHandler();
+		}
+		// TODO: JDBC leak protection?
+		this.running = false;
+		this.runThread = null;
+	}
+
+	private void resetUrlHandler() {
+		// Tomcat always tries to set this, even if it was already set
+		Field field = ReflectionUtils.findField(URL.class, "factory");
+		ReflectionUtils.makeAccessible(field);
+		ReflectionUtils.setField(field, null, null);
+	}
+
+	public boolean isRunning() {
+		return running;
+	}
+
+	public Throwable getError() {
+		return this.error;
+	}
+
+}

--- a/function-invokers/java-function-invoker/src/main/java/io/sk8s/invoker/java/server/JavaFunctionInvokerApplication.java
+++ b/function-invokers/java-function-invoker/src/main/java/io/sk8s/invoker/java/server/JavaFunctionInvokerApplication.java
@@ -56,11 +56,11 @@ public class JavaFunctionInvokerApplication {
 
 	private boolean isolated(String[] args) {
 		for (String arg : args) {
-			if (arg.equals("--function.runner.isolated=true")) {
-				return true;
+			if (arg.equals("--function.runner.isolated=false")) {
+				return false;
 			}
 		}
-		return false;
+		return true;
 	}
 
 	private URLClassLoader createClassLoader() {

--- a/function-invokers/java-function-invoker/src/main/java/io/sk8s/invoker/java/server/JavaFunctionInvokerApplication.java
+++ b/function-invokers/java-function-invoker/src/main/java/io/sk8s/invoker/java/server/JavaFunctionInvokerApplication.java
@@ -16,8 +16,19 @@
 
 package io.sk8s.invoker.java.server;
 
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.jar.JarFile;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.util.StringUtils;
 
 /**
  * @author Mark Fisher
@@ -25,7 +36,96 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class JavaFunctionInvokerApplication {
 
+	private static Log logger = LogFactory.getLog(JavaFunctionInvokerApplication.class);
+
 	public static void main(String[] args) {
-		SpringApplication.run(JavaFunctionInvokerApplication.class, args);
+		JavaFunctionInvokerApplication application = new JavaFunctionInvokerApplication();
+		if (application.isolated(args)) {
+			application.runner().run(args);
+		}
+		else {
+			SpringApplication.run(JavaFunctionInvokerApplication.class, args);
+		}
 	}
+
+	ApplicationRunner runner() {
+		ApplicationRunner runner = new ApplicationRunner(createClassLoader(),
+				JavaFunctionInvokerApplication.class.getName());
+		return runner;
+	}
+
+	private boolean isolated(String[] args) {
+		for (String arg : args) {
+			if (arg.equals("--function.runner.isolated=true")) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private URLClassLoader createClassLoader() {
+		ClassLoader base = getClass().getClassLoader();
+		if (!(base instanceof URLClassLoader)) {
+			throw new IllegalStateException("Need a URL class loader, found: " + base);
+		}
+		@SuppressWarnings("resource")
+		URLClassLoader urlClassLoader = (URLClassLoader) base;
+		URL[] urls = urlClassLoader.getURLs();
+		if (urls.length == 1) {
+			URL[] classpath = extractClasspath(urls[0]);
+			if (classpath != null) {
+				urls = classpath;
+			}
+		}
+		List<URL> child = new ArrayList<>();
+		List<URL> parent = new ArrayList<>();
+		for (URL url : urls) {
+			child.add(url);
+		}
+		for (URL url : urls) {
+			if (isRoot(StringUtils.getFilename(clean(url.toString())))) {
+				parent.add(url);
+				child.remove(url);
+			}
+		}
+		logger.info("Parent: " + parent);
+		logger.info("Child: " + child);
+		if (!parent.isEmpty()) {
+			base = new URLClassLoader(parent.toArray(new URL[0]), base.getParent());
+		}
+		return new URLClassLoader(child.toArray(new URL[0]), base);
+	}
+
+	private boolean isRoot(String file) {
+		return file.startsWith("reactor-core") || file.startsWith("reactive-streams");
+	}
+
+	private String clean(String jar) {
+		// This works with fat jars like Spring Boot where the path elements look like
+		// jar:file:...something.jar!/.
+		return jar.endsWith("!/") ? jar.substring(0, jar.length() - 2) : jar;
+	}
+
+	private URL[] extractClasspath(URL url) {
+		// This works for a jar indirection like in surefire and IntelliJ
+		if (url.toString().endsWith(".jar")) {
+			JarFile jar;
+			try {
+				jar = new JarFile(new File(url.toURI()));
+				String path = jar.getManifest().getMainAttributes()
+						.getValue("Class-Path");
+				if (path != null) {
+					List<URL> result = new ArrayList<>();
+					for (String element : path.split(" ")) {
+						result.add(new URL(element));
+					}
+					return result.toArray(new URL[0]);
+				}
+			}
+			catch (Exception e) {
+			}
+		}
+		return null;
+	}
+
 }

--- a/function-invokers/java-function-invoker/src/test/java/io/sk8s/invoker/java/AdhocTestSuite.java
+++ b/function-invokers/java-function-invoker/src/test/java/io/sk8s/invoker/java/AdhocTestSuite.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sk8s.invoker.java;
+
+import io.sk8s.invoker.java.server.ComposedJavaFunctionInvokerApplicationTests;
+import io.sk8s.invoker.java.server.IsolatedTests;
+
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+/**
+ * A test suite for probing weird ordering problems in the tests.
+ *
+ * @author Dave Syer
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ ComposedJavaFunctionInvokerApplicationTests.class,
+		IsolatedTests.class })
+@Ignore
+public class AdhocTestSuite {
+
+}

--- a/function-invokers/java-function-invoker/src/test/java/io/sk8s/invoker/java/function/FluxDoubler.java
+++ b/function-invokers/java-function-invoker/src/test/java/io/sk8s/invoker/java/function/FluxDoubler.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sk8s.invoker.java.function;
+
+import java.util.function.Function;
+
+import reactor.core.publisher.Flux;
+
+public class FluxDoubler implements Function<Flux<Integer>, Flux<Integer>> {
+	@Override
+	public Flux<Integer> apply(Flux<Integer> integer) {
+		return integer.map(i -> 2*i);
+	}
+}

--- a/function-invokers/java-function-invoker/src/test/java/io/sk8s/invoker/java/function/FunctionConfigurationTests.java
+++ b/function-invokers/java-function-invoker/src/test/java/io/sk8s/invoker/java/function/FunctionConfigurationTests.java
@@ -32,6 +32,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.rule.OutputCapture;
 import org.springframework.cloud.function.context.InMemoryFunctionCatalog;
 import org.springframework.cloud.function.core.FunctionCatalog;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -42,6 +43,7 @@ import static org.junit.Assert.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = { FunctionConfiguration.class, FunctionProperties.class,
 		InMemoryFunctionCatalog.class })
+@DirtiesContext
 public abstract class FunctionConfigurationTests {
 
 	@TestPropertySource(properties = {

--- a/function-invokers/java-function-invoker/src/test/java/io/sk8s/invoker/java/server/ComposedJavaFunctionInvokerApplicationTests.java
+++ b/function-invokers/java-function-invoker/src/test/java/io/sk8s/invoker/java/server/ComposedJavaFunctionInvokerApplicationTests.java
@@ -29,6 +29,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -41,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = "function.uri=file:target/test-classes"
 		+ "?io.sk8s.invoker.java.function.Doubler,io.sk8s.invoker.java.function.Frenchizer")
+@DirtiesContext
 public class ComposedJavaFunctionInvokerApplicationTests {
 
 	@Autowired

--- a/function-invokers/java-function-invoker/src/test/java/io/sk8s/invoker/java/server/IsolatedTests.java
+++ b/function-invokers/java-function-invoker/src/test/java/io/sk8s/invoker/java/server/IsolatedTests.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sk8s.invoker.java.server;
+
+import java.net.URI;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.SocketUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public class IsolatedTests {
+
+	private TestRestTemplate rest;
+	private int port = SocketUtils.findAvailableTcpPort();
+	private ApplicationRunner runner;
+
+	@Rule
+	public ExpectedException expected = ExpectedException.none();
+
+	@Before
+	public void init() {
+		runner = new JavaFunctionInvokerApplication().runner();
+		rest = new TestRestTemplate();
+	}
+
+	@After
+	public void close() {
+		if (runner != null) {
+			runner.close();
+		}
+	}
+
+	@Test
+	public void fluxFunctionNotIsolated() throws Exception {
+		expected.expect(BeanCreationException.class);
+		SpringApplication.run(JavaFunctionInvokerApplication.class,
+				"--server.port=" + port, "--function.uri=file:target/test-classes"
+						+ "?io.sk8s.invoker.java.function.FluxDoubler");
+	}
+
+	@Test
+	public void fluxFunction() throws Exception {
+		runner.run("--server.port=" + port, "--function.uri=file:target/test-classes"
+				+ "?io.sk8s.invoker.java.function.FluxDoubler");
+		ResponseEntity<String> result = rest
+				.exchange(
+						RequestEntity.post(new URI("http://localhost:" + port + "/"))
+								.contentType(MediaType.TEXT_PLAIN).body("5"),
+						String.class);
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+		// Check single valued response in s-c-f
+		assertThat(result.getBody()).isEqualTo("[10]");
+	}
+
+	@Test
+	public void simpleFunction() throws Exception {
+		runner.run("--server.port=" + port, "--function.uri=file:target/test-classes"
+				+ "?io.sk8s.invoker.java.function.Doubler");
+		ResponseEntity<String> result = rest
+				.exchange(
+						RequestEntity.post(new URI("http://localhost:" + port + "/"))
+								.contentType(MediaType.TEXT_PLAIN).body("5"),
+						String.class);
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(result.getBody()).isEqualTo("10");
+	}
+}

--- a/function-invokers/java-function-invoker/src/test/java/io/sk8s/invoker/java/server/JavaFunctionInvokerApplicationTests.java
+++ b/function-invokers/java-function-invoker/src/test/java/io/sk8s/invoker/java/server/JavaFunctionInvokerApplicationTests.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -30,6 +29,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -40,9 +40,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-@TestPropertySource(properties = "function.uri=file:target/test-classes"
-		+ "?io.sk8s.invoker.java.function.Doubler")
-public class JavaFunctionInvokerApplicationTests {
+@TestPropertySource(properties = {
+		"function.uri=file:target/test-classes?io.sk8s.invoker.java.function.Doubler" })
+@DirtiesContext
+public abstract class JavaFunctionInvokerApplicationTests {
 
 	@Autowired
 	private TestRestTemplate rest;

--- a/function-invokers/java-function-invoker/src/test/resources/logback-test.xml
+++ b/function-invokers/java-function-invoker/src/test/resources/logback-test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+	<include resource="org/springframework/boot/logging/logback/base.xml"/>
+	<logger name="org.springframework.cloud.sleuth" level="TRACE"/>
+	<logger name="org.springframework.boot.autoconfigure.logging" level="INFO"/>
+	<logger name="org.springframework.cloud.sleuth.log" level="DEBUG"/>
+	<logger name="org.springframework.cloud.sleuth.trace" level="DEBUG"/>
+	<logger name="org.springframework.cloud.sleuth.instrument.rxjava" level="DEBUG"/>
+	<root level="INFO">
+		<appender-ref ref="CONSOLE"/>
+		<appender-ref ref="FILE"/>
+	</root>
+</configuration>


### PR DESCRIPTION
User has to add --function.runner.isolated=true on the command line. In
this case the app is launched in an isolated classpath with reactor in the
parent class loader. Then the function is launched in a class loader with
the same parent so it can support functions of Flux.