### PR TITLE
Set the context class loader during function creation

### DIFF
--- a/function-invokers/java-function-invoker/src/test/java/io/sk8s/invoker/java/function/FunctionApp.java
+++ b/function-invokers/java-function-invoker/src/test/java/io/sk8s/invoker/java/function/FunctionApp.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sk8s.invoker.java.function;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * @author Dave Syer
+ *
+ */
+@SpringBootApplication
+public class FunctionApp {
+
+	public static void main(String[] args) throws Exception {
+		SpringApplication.run(FunctionApp.class, args);
+	}
+
+}

--- a/function-invokers/java-function-invoker/src/test/java/io/sk8s/invoker/java/function/SpringDoubler.java
+++ b/function-invokers/java-function-invoker/src/test/java/io/sk8s/invoker/java/function/SpringDoubler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sk8s.invoker.java.function;
+
+import java.util.function.Function;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.Banner.Mode;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+
+public class SpringDoubler implements Function<Integer, Integer> {
+
+	@Autowired
+	private ConfigurableApplicationContext context;
+
+	@PostConstruct
+	public void init() {
+		if (this.context == null) {
+			context = new SpringApplicationBuilder(FunctionApp.class).bannerMode(Mode.OFF)
+					.web(false).run();
+		}
+	}
+
+	@PreDestroy
+	public void close() {
+		if (context != null) {
+			context.close();
+		}
+	}
+
+	@Override
+	public Integer apply(Integer integer) {
+		return 2 * integer;
+	}
+
+}

--- a/function-invokers/java-function-invoker/src/test/java/io/sk8s/invoker/java/server/IsolatedTests.java
+++ b/function-invokers/java-function-invoker/src/test/java/io/sk8s/invoker/java/server/IsolatedTests.java
@@ -95,4 +95,17 @@ public class IsolatedTests {
 		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
 		assertThat(result.getBody()).isEqualTo("10");
 	}
+
+	@Test
+	public void appClassPath() throws Exception {
+		runner.run("--server.port=" + port,
+				"--function.uri=app:classpath?handler=io.sk8s.invoker.java.function.SpringDoubler");
+		ResponseEntity<String> result = rest
+				.exchange(
+						RequestEntity.post(new URI("http://localhost:" + port + "/"))
+								.contentType(MediaType.TEXT_PLAIN).body("5"),
+						String.class);
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(result.getBody()).isEqualTo("10");
+	}
 }


### PR DESCRIPTION
Lots of things use the thread context loader, including Spring
itself when creating services from spring.factories. So we need to
set it to something sane when the functions are being instantiated.

Also adds a new special URL for the function.uri. If the user uses
"app:classpath" then the classpath URLs from the app are re-used.
Very useful for testing, but might also be occasionally useful
for real functions that don't want to be a fat jar and
only need Spring stuff that is already in the invoker.